### PR TITLE
add weak dependencies for rhel8

### DIFF
--- a/check_pgbackrest.spec
+++ b/check_pgbackrest.spec
@@ -3,7 +3,7 @@
 Name: nagios-plugins-pgbackrest
 Version: 1.9
 Release: 1
-Summary: pgBackRest backup check plugin for Nagios 
+Summary: pgBackRest backup check plugin for Nagios
 License: PostgreSQL
 Group: Applications/Databases
 Url: https://github.com/dalibo/check_pgbackrest
@@ -13,7 +13,11 @@ BuildArch: noarch
 BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
 Requires: nagios-plugins
 Requires: perl-JSON
-Requires: perl-Net-SFTP-Foreign
+%if 0%{?rhel} && 0%{?rhel} >= 8
+Recommends: perl-Net-SFTP-Foreign
+Recommends: perl-Config-IniFiles
+Recommends: perl-Net-Amazon-S3
+%endif
 Requires: perl-Data-Dumper
 Provides: check_pgbackrest = %{version}
 


### PR DESCRIPTION
Allow for weak dependency in RHEL8 for the following packages:

- `perl-Net-SFTP-Foreign`
- `perl-Config-IniFiles`
- `perl-Net-Amazon-S3`

The dependencies for Amazon S3 aren't included at all but the package `perl-Net-SFTP-Foreign` is hard forced. In a stock install of RHEL/OracleLinux 8 this package (from EPEL) has a dependency `perl(IO::Pty)`, which is in the CodeReady Builder Channel. In RHEL8 not all systems have this channel enabled, which is full of dev-tools, and the package fails to install on regular systems.

This allows for installation on 'normal' systems but if you need this functionality, you should get those packages another way.
